### PR TITLE
tectonic: lock `--web-bundle` for reproducible builds

### DIFF
--- a/pkgs/tools/typesetting/tectonic/default.nix
+++ b/pkgs/tools/typesetting/tectonic/default.nix
@@ -15,7 +15,6 @@
 , harfbuzz
 , openssl
 , pkg-config
-, makeBinaryWrapper
 , icu
 }:
 

--- a/pkgs/tools/typesetting/tectonic/default.nix
+++ b/pkgs/tools/typesetting/tectonic/default.nix
@@ -21,17 +21,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "tectonic";
-  version = "0.14.1";
+  version = "0.15.0";
 
   src = fetchFromGitHub {
     owner = "tectonic-typesetting";
     repo = "tectonic";
     rev = "tectonic@${version}";
     fetchSubmodules = true;
-    sha256 = "sha256-Cd8YzjU5mCA5DmgLBjg8eVRc87chVVIXinJuf8cNw3o=";
+    sha256 = "sha256-xZHYiaQ8ASUwu0ieHIXcjRaH06SQoB6OR1y7Ok+FjAs=";
   };
 
-  cargoHash = "sha256-1WjZbmZFPB1+QYpjqq5Y+fDkMZNmWJYIxmMFWg7Tiac=";
+  cargoHash = "sha256-niMgb4zsTWHw5yaa4kJOZzpOzO5gMG4k3cTHwSV+wmY=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/tools/typesetting/tectonic/tests.nix
+++ b/pkgs/tools/typesetting/tectonic/tests.nix
@@ -3,6 +3,7 @@
 
 { lib
 , fetchFromGitHub
+, writeText
 , runCommand
 , tectonic
 , curl
@@ -26,7 +27,7 @@ let
   };
   testfiles = "${biber-dev-source}/testfiles";
 
-  noNetNotice = builtins.toFile "tectonic-offline-notice" ''
+  noNetNotice = writeText "tectonic-offline-notice" ''
     # To fetch tectonic's web bundle, the tests require internet access,
     # which is not available in the current environment.
   '';
@@ -83,5 +84,10 @@ lib.mapAttrs networkRequiringTestPkg {
     # tectonic caches in the $HOME directory, so set it to $PWD
     export HOME=$PWD
     tectonic -X compile ./test.tex
+  '';
+
+  workspace = ''
+    tectonic -X new
+    cat Tectonic.toml | grep "${tectonic.bundle.url}"
   '';
 }

--- a/pkgs/tools/typesetting/tectonic/wrapper.nix
+++ b/pkgs/tools/typesetting/tectonic/wrapper.nix
@@ -1,41 +1,43 @@
 { lib
 , symlinkJoin
+, tectonic
 , tectonic-unwrapped
 , biber-for-tectonic
-, makeWrapper
+, makeBinaryWrapper
 , callPackage
 }:
+
+let
+
+  # The version locked tectonic web bundle, redirected from:
+  #   https://relay.fullyjustified.net/default_bundle_v33.tar
+  # To check for updates, see:
+  #   https://github.com/tectonic-typesetting/tectonic/blob/master/crates/bundles/src/lib.rs
+  # ... and look up `get_fallback_bundle_url`.
+  TECTONIC_WEB_BUNDLE_LOCKED = "https://data1.fullyjustified.net/tlextras-2022.0r0.tar";
+
+in
 
 symlinkJoin {
   name = "${tectonic-unwrapped.pname}-wrapped-${tectonic-unwrapped.version}";
   paths = [ tectonic-unwrapped ];
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [ makeBinaryWrapper ];
 
   passthru = {
     unwrapped = tectonic-unwrapped;
     biber = biber-for-tectonic;
     tests = callPackage ./tests.nix { };
+    bundle.url = TECTONIC_WEB_BUNDLE_LOCKED;
   };
 
   # Replace the unwrapped tectonic with the one wrapping it with biber
   postBuild = ''
     rm $out/bin/{tectonic,nextonic}
   ''
-    # Ideally, we would have liked to also pin the version of the online TeX
-    # bundle that Tectonic's developer distribute, so that the `biber` version
-    # and the `biblatex` version distributed from there are compatible.
-    # However, that is not currently possible, due to lack of upstream support
-    # for specifying this in runtime, there were 2 suggestions sent upstream
-    # that suggested a way of improving the situation:
-    #
-    # - https://github.com/tectonic-typesetting/tectonic/pull/1132
-    # - https://github.com/tectonic-typesetting/tectonic/pull/1131
-    #
-    # The 1st suggestion seems more promising as it'd allow us to simply use
-    # makeWrapper's --add-flags option. However, the PR linked above is not
-    # complete, and as of currently, upstream hasn't even reviewed it, or
-    # commented on the idea.
+    # Pin the version of the online TeX bundle that Tectonic's developer
+    # distribute, so that the `biber` version and the `biblatex` version
+    # distributed from there are compatible.
     #
     # Note also that upstream has announced that they will put less time and
     # energy for the project:
@@ -47,7 +49,8 @@ symlinkJoin {
     # won't require a higher version of biber.
   + ''
     makeWrapper ${lib.getBin tectonic-unwrapped}/bin/tectonic $out/bin/tectonic \
-      --prefix PATH : "${lib.getBin biber-for-tectonic}/bin"
+      --prefix PATH : "${lib.getBin biber-for-tectonic}/bin" \
+      --add-flags "--web-bundle ${tectonic.passthru.bundle.url}"
     ln -s $out/bin/tectonic $out/bin/nextonic
   '';
 


### PR DESCRIPTION
## Warning

This is a mock pull request for testing and is not yet ready to be upstreamed at the moment.

## Description of changes

tectonic: lock `--web-bundle` for reproducible builds

This PR depends on https://github.com/tectonic-typesetting/tectonic/pull/1132
