### PR TITLE
Revert "hydra-check: patch to fix x86_64-darwin, rust 1.88"

### DIFF
--- a/pkgs/by-name/hy/hydra-check/package.nix
+++ b/pkgs/by-name/hy/hydra-check/package.nix
@@ -7,9 +7,12 @@
   stdenv,
   installShellFiles,
   versionCheckHook,
+  testers,
+  curl,
+  cacert,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: rec {
   pname = "hydra-check";
   version = "2.0.4";
 
@@ -45,6 +48,27 @@ rustPlatform.buildRustPackage rec {
 
   doInstallCheck = true;
 
+  passthru.tests.mainCommand =
+    testers.runCommand # allows internet access
+      {
+        name = "hydra-check-test";
+        script = ''
+          set -e
+          if curl hydra.nixos.org > /dev/null; then
+            hydra-check
+          else
+            echo "no internet access, aborting test"
+          fi
+          touch $out
+        '';
+
+        nativeBuildInputs = [
+          finalAttrs.finalPackage
+          curl
+          cacert # for https connectivity
+        ];
+      };
+
   meta = {
     description = "Check hydra for the build status of a package";
     homepage = "https://github.com/nix-community/hydra-check";
@@ -57,4 +81,4 @@ rustPlatform.buildRustPackage rec {
     ];
     mainProgram = "hydra-check";
   };
-}
+})


### PR DESCRIPTION
After rust 1.89 is merged into master we can revert the redundant patch.

This reverts commit 87f679dc0a945d8664ffa34bdda7b8147b7e2656.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
